### PR TITLE
ci(front): fix actions timezone on client-test

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -8,6 +8,7 @@ on:
 env:
   workdir: client
   node-version: lts/*
+  TZ: Asia/Tokyo
 
 jobs:
   front-filter:


### PR DESCRIPTION
`client-test` でのタイムゾーンを `Asia/Tokyo` に固定

Closes: #199 